### PR TITLE
don't enqueue CSS and JS when not a singular post

### DIFF
--- a/class.tilda.php
+++ b/class.tilda.php
@@ -226,10 +226,15 @@ class Tilda
 
     public static function enqueue_scripts()
     {
-        global $post;
 
-        if ($post) {
-            $data = get_post_meta($post->ID, '_tilda', true);
+        if (!is_singular()) {
+            return false;
+        }
+
+        $the_post = get_post();
+
+        if ($the_post) {
+            $data = get_post_meta($the_post->ID, '_tilda', true);
 
             if(isset($data['status']) && $data['status'] == 'on') {
                 Tilda::$active_on_page = true;
@@ -239,7 +244,7 @@ class Tilda
 
 
             if (isset($data) && isset($data["status"]) && $data["status"] == 'on') {
-                $page = self::get_local_page($data["page_id"],$data["project_id"], $post->ID);
+                $page = self::get_local_page($data["page_id"],$data["project_id"], $the_post->ID);
 
                 $css_links = $page->css;
                 $js_links = $page->js;


### PR DESCRIPTION
Возможно, это сломает кому-то стили оформления, но мне ломает стили оформления текущее поведение.

Потому что при выводе списка постов подключаются js-ы и (что важнее) CSS-стили страниц из списка. Или только первой страницы из списка, честно говоря я не разбирался. Но подключает, это факт.

А в этих стилях, например, прописаны все заголовки (h1,h2,h3 и т.д.), что ломает верстку страницы.