### PR TITLE
fix compressed response not returned correctly by curl

### DIFF
--- a/class.tilda.php
+++ b/class.tilda.php
@@ -410,6 +410,7 @@ class Tilda
             if ($curl = curl_init()) {
                 curl_setopt($curl, CURLOPT_URL, $url);
                 curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+                curl_setopt($curl, CURLOPT_ENCODING, "");
                 $out = curl_exec($curl);
                 curl_close($curl);
             } else {


### PR DESCRIPTION
Возникла проблема, что ответ от API тильды внезапно прерывается (примерно на 86-88 кб)
По всей видимости,  удаленный сервер передает данные кусками, отправляя заголовок Transfer-Encoding: chunked, но при этом разрывает соединение раньше, чем передаст последний кусок (chunk) нулевого размера 0<CRLF><CRLF> о чем и сообщает curl (в консоли)

curl: (18) transfer closed with outstanding read data remaining