### PR TITLE
Added timestamp for CSS files

### DIFF
--- a/class.tilda-admin.php
+++ b/class.tilda-admin.php
@@ -1230,7 +1230,7 @@ class Tilda_Admin {
 		foreach ( $arCSS as $file ) {
 			$tildapage->css[] = $upload_path . 'css/' . $file->to;
 			$arDownload[]     = [
-				'from_url' => $file->from,
+				'from_url' => $file->from . '?t=' . time(),
 				'to_dir'   => $upload_dir . 'css/' . $file->to,
 			];
 		}


### PR DESCRIPTION


Добавлен timestamp при синхронизации CSS с Тильды. Получаем всегда последние изменения, особенно актуально для tilda-blocks-page*.css

Что починил этот фикс для меня:

На существующей странице в Тильде добавил форму в попапе (702). Всё настроено, паблишу, проверяю превью на Тильде - всё отлично. Синхронизирую эту страницу в WP - форма работает, НО БЕЗ СТИЛЕЙ. Смотрю скачанный tilda-blocks-page*.css и актуальный на превью Тильды: отличаются на 4 кб - как раз без стилей для .t702. Смотрю, что сама тильда в превью запрашивает этот файл с меткой времени - и там всё есть. Смотрю в код этого плагина - стили запрашиваются без timestamp!

Добавил метку времени, потестил на своём сайте - всё работает идеально.

На нашем сайте пользователи плагина до меня сталкивались с таким поведением и их решением было ПЕРЕСОЗДАНИЕ СТРАНИЦЫ В ТИЛЬДЕ (!!!). Мне такое не подходит - ловите, пожалуйста, правку.